### PR TITLE
Gpu density mod

### DIFF
--- a/Resource/GPUStruct/ChunkDispatchKeyGPU.cs
+++ b/Resource/GPUStruct/ChunkDispatchKeyGPU.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 [StructLayout(LayoutKind.Sequential)]
 public struct ChunkDispatchKeyGPU
 {
+    public uint GlobalIndex;
     public Vector3 CoordPos;
     public int LodIndex;
 }

--- a/Resource/Shaders/ChunkFunctions.hlsl
+++ b/Resource/Shaders/ChunkFunctions.hlsl
@@ -39,17 +39,24 @@ ChunkDispatchKeyInfo GetChunkAccessCubes(uint3 id, uint offset, StructuredBuffer
     uint keyCount, stride;
     keys.GetDimensions(keyCount, stride);
 
-    uint logicalX = keyCount * CubesPerAxis;
-    if (id.x >= logicalX || id.y >= CubesPerAxis || id.z >= CubesPerAxis)
+    // Compute chunk within this dispatch
+    uint chunkLocal = id.x / CubesPerAxis;
+    uint localX = id.x % CubesPerAxis;
+
+    // Apply global offset for key lookup
+    r.KeyIndex = chunkLocal + offset;
+
+    // Safety check that is for some reason breaks if not here.
+    // 11/2 - I don't remember why I added this, but if this is missing
+    // chunks dont render correctly which seems like we are overdispatching.
+    if (r.KeyIndex >= keyCount || id.y >= CubesPerAxis || id.z >= CubesPerAxis)
     {
-        r.KeyIndex = -1;
+        r.SampleIndex = -1;
         return r;
     }
 
-    // Map X → (KeyIndex, localX)
-    float invCubesPerAxis = 1.0 / CubesPerAxis;
-    r.KeyIndex = (id.x * invCubesPerAxis) + offset;
-    r.LocalVoxelCoord = uint3(id.x - r.KeyIndex * CubesPerAxis, id.y, id.z);
+    // local coordinates stay within 0..sampleSize.x-1
+    r.LocalVoxelCoord = uint3(localX, id.y, id.z);
     
     // Fetch key and compute world position
     ChunkDispatchKey key = keys[r.KeyIndex];

--- a/Resource/Shaders/ChunkFunctions.hlsl
+++ b/Resource/Shaders/ChunkFunctions.hlsl
@@ -53,6 +53,7 @@ ChunkDispatchKeyInfo GetChunkAccessCubes(uint3 id, StructuredBuffer<ChunkDispatc
     
     // Fetch key and compute world position
     ChunkDispatchKey key = keys[r.KeyIndex];
+    r.GlobalIndex = key.GlobalIndex;
     r.chunk = key;
     r.WorldPos = ToWorld(key.CoordPos, key.LodIndex) + 
                  float3(r.LocalVoxelCoord) * GetCubeSizeStep(r.chunk.LodIndex);
@@ -93,6 +94,7 @@ ChunkDispatchKeyInfo GetChunkAccessSamples(uint3 id, StructuredBuffer<ChunkDispa
     r.SampleIndex = GetVoxelSampleIndexRaw(r.LocalVoxelCoord, r.KeyIndex, sampleSize);
 
     ChunkDispatchKey key = keys[r.KeyIndex];
+    r.GlobalIndex = key.GlobalIndex;
     r.chunk = key;
     r.WorldPos = ToWorld(key.CoordPos, key.LodIndex) + float3(r.LocalVoxelCoord) * GetCubeSizeStep(r.chunk.LodIndex);
 

--- a/Resource/Shaders/ChunkFunctions.hlsl
+++ b/Resource/Shaders/ChunkFunctions.hlsl
@@ -32,7 +32,7 @@ int GetVoxelSampleIndex(int3 pos, int KeyIndex, int3 totalSampleSize)
 //   id     : Dispatch thread ID (x, y, z) from the compute shader
 //   sampleSize.x, sampleSize.y, sampleSize.z : Chunk dimensions in voxels (per axis)
 //   keys   : Structured buffer of all active chunks to process
-ChunkDispatchKeyInfo GetChunkAccessCubes(uint3 id, StructuredBuffer<ChunkDispatchKey> keys)
+ChunkDispatchKeyInfo GetChunkAccessCubes(uint3 id, uint offset, StructuredBuffer<ChunkDispatchKey> keys)
 {
     ChunkDispatchKeyInfo r;
 
@@ -48,12 +48,11 @@ ChunkDispatchKeyInfo GetChunkAccessCubes(uint3 id, StructuredBuffer<ChunkDispatc
 
     // Map X → (KeyIndex, localX)
     float invCubesPerAxis = 1.0 / CubesPerAxis;
-    r.KeyIndex = (id.x * invCubesPerAxis);
+    r.KeyIndex = (id.x * invCubesPerAxis) + offset;
     r.LocalVoxelCoord = uint3(id.x - r.KeyIndex * CubesPerAxis, id.y, id.z);
     
     // Fetch key and compute world position
     ChunkDispatchKey key = keys[r.KeyIndex];
-    r.GlobalIndex = key.GlobalIndex;
     r.chunk = key;
     r.WorldPos = ToWorld(key.CoordPos, key.LodIndex) + 
                  float3(r.LocalVoxelCoord) * GetCubeSizeStep(r.chunk.LodIndex);
@@ -72,7 +71,7 @@ ChunkDispatchKeyInfo GetChunkAccessCubes(uint3 id, StructuredBuffer<ChunkDispatc
 //   id     : Dispatch thread ID (x, y, z) from the compute shader
 //   sampleSize.x, sampleSize.y, sampleSize.z : Chunk dimensions in voxels (per axis)
 //   keys   : Structured buffer of all active chunks to process
-ChunkDispatchKeyInfo GetChunkAccessSamples(uint3 id, StructuredBuffer<ChunkDispatchKey> keys)
+ChunkDispatchKeyInfo GetChunkAccessSamples(uint3 id, uint offset, StructuredBuffer<ChunkDispatchKey> keys)
 {
     ChunkDispatchKeyInfo r;
 
@@ -80,26 +79,37 @@ ChunkDispatchKeyInfo GetChunkAccessSamples(uint3 id, StructuredBuffer<ChunkDispa
     uint keyCount, strideBytes;
     keys.GetDimensions(keyCount, strideBytes);
 
-    uint logicalX = keyCount * sampleSize.x;
-    if (id.x >= logicalX || id.y >= sampleSize.y || id.z >= sampleSize.z)
+    // Compute chunk within this dispatch
+    uint chunkLocal = id.x / sampleSize.x;
+    uint localX = id.x % sampleSize.x;
+
+    // Apply global offset for key lookup
+    r.KeyIndex = chunkLocal + offset;
+
+    // Safety check that is for some reason breaks if not here.
+    // 11/2 - I don't remember why I added this, but if this is missing
+    // chunks dont render correctly which seems like we are overdispatching.
+    if (r.KeyIndex >= keyCount || id.y >= sampleSize.y || id.z >= sampleSize.z)
     {
         r.SampleIndex = -1;
         return r;
     }
 
-    float invCubesPerAxis = 1.0 / sampleSize.x;
-    r.KeyIndex = (uint) floor(id.x * invCubesPerAxis);
-    r.LocalVoxelCoord = uint3(id.x - r.KeyIndex * sampleSize.x, id.y, id.z);
+    // local coordinates stay within 0..sampleSize.x-1
+    r.LocalVoxelCoord = uint3(localX, id.y, id.z);
 
+    // This points to the exact position in the map.
     r.SampleIndex = GetVoxelSampleIndexRaw(r.LocalVoxelCoord, r.KeyIndex, sampleSize);
 
+    // Set key data
     ChunkDispatchKey key = keys[r.KeyIndex];
-    r.GlobalIndex = key.GlobalIndex;
     r.chunk = key;
-    r.WorldPos = ToWorld(key.CoordPos, key.LodIndex) + float3(r.LocalVoxelCoord) * GetCubeSizeStep(r.chunk.LodIndex);
+    r.WorldPos = ToWorld(key.CoordPos, key.LodIndex)
+               + float3(r.LocalVoxelCoord) * GetCubeSizeStep(r.chunk.LodIndex);
 
     return r;
 }
+
 
 
 #endif

--- a/Resource/Shaders/ChunkStruct.hlsl
+++ b/Resource/Shaders/ChunkStruct.hlsl
@@ -9,6 +9,7 @@
 // LodIndex = step size based on current LOD
 struct ChunkDispatchKey
 {
+    uint GlobalIndex;
     float3 CoordPos;
     uint LodIndex;
 };
@@ -18,6 +19,7 @@ struct ChunkDispatchKey
 // world position, and the original chunk key.
 struct ChunkDispatchKeyInfo
 {
+    uint GlobalIndex;
     uint KeyIndex;
     uint SampleIndex;
     uint3 LocalVoxelCoord;

--- a/Resource/Shaders/ChunkStruct.hlsl
+++ b/Resource/Shaders/ChunkStruct.hlsl
@@ -19,7 +19,6 @@ struct ChunkDispatchKey
 // world position, and the original chunk key.
 struct ChunkDispatchKeyInfo
 {
-    uint GlobalIndex;
     uint KeyIndex;
     uint SampleIndex;
     uint3 LocalVoxelCoord;

--- a/Resource/Shaders/Kernals/SimpleMarchingCubes.compute
+++ b/Resource/Shaders/Kernals/SimpleMarchingCubes.compute
@@ -13,6 +13,8 @@
 #include "../Biomes/BiomeSampler.hlsl"
 #include "../ChunkColoring.hlsl"
 
+uint Offset;
+
 /* Inputs */
 StructuredBuffer<ChunkDispatchKey> ChunkInputs;
 RWStructuredBuffer<float> DensityMap;
@@ -38,7 +40,7 @@ groupshared uint gHasBelow;
 [numthreads(4, 4, 4)]
 void GenerateDensityMap(uint3 id : SV_DispatchThreadID)
 {
-    ChunkDispatchKeyInfo info = GetChunkAccessSamples(id, ChunkInputs);
+    ChunkDispatchKeyInfo info = GetChunkAccessSamples(id, Offset, ChunkInputs);
     if (info.SampleIndex < 0)
         return;
     
@@ -110,7 +112,7 @@ void GenerateSurfaceMask(uint3 groupId : SV_GroupID, uint3 tid : SV_GroupThreadI
 [numthreads(4, 4, 4)]
 void RunMarchingCubes(uint3 id : SV_DispatchThreadID)
 {
-    ChunkDispatchKeyInfo access = GetChunkAccessCubes(id, ChunkInputs);
+    ChunkDispatchKeyInfo access = GetChunkAccessCubes(id, 0, ChunkInputs);
     if (access.KeyIndex < 0) 
         return;
     

--- a/Terrain/Core/ChunkKey.cs
+++ b/Terrain/Core/ChunkKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Unity.Mathematics;
 using UnityEngine;
 
@@ -56,8 +57,19 @@ public readonly struct ChunkKey : IEquatable<ChunkKey>
     /// <summary>
     /// Generates a unique hash so this key works in dictionaries/sets.
     /// </summary>
-    public override int GetHashCode() =>
-        HashCode.Combine(Coordinates, LODIndex);
+    /// <remarks>While trying to resolve memory issues in <see cref="ChunkRenderBucket"/> with large item amounts
+    /// 400k elements. I found this https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-overriding-gethashcode/263416#263416
+    /// it made no change.</remarks>
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int h = Coordinates.x * 73856093
+                  ^ Coordinates.y * 19349663
+                  ^ Coordinates.z * 83492791;
+            return (h ^ (LODIndex * 486187739));
+        }
+    }
 
     /// <summary>
     /// Human-readable string version (good for debugging/logs).

--- a/Terrain/Core/ChunkKey.cs
+++ b/Terrain/Core/ChunkKey.cs
@@ -1,4 +1,5 @@
 using System;
+using Unity.Mathematics;
 using UnityEngine;
 
 /// <summary>
@@ -33,6 +34,11 @@ public readonly struct ChunkKey : IEquatable<ChunkKey>
         Coordinates = coords;
         LODIndex = lod;
     }
+
+    /// <summary>
+    /// An invalid key reference.
+    /// </summary>
+    public static readonly ChunkKey Invalid = new ChunkKey(new Vector3Int(int.MaxValue, int.MaxValue, int.MaxValue), -1);
 
     /// <summary>
     /// Checks if another ChunkKey matches this one

--- a/Terrain/Core/Interfaces/IChunkGenerator.cs
+++ b/Terrain/Core/Interfaces/IChunkGenerator.cs
@@ -21,7 +21,7 @@ public interface IChunkGenerator : IDisposable
     /// </summary>
     /// <param name="keys">List of chunk keys to generate.</param>
     /// <returns>GPU data set for the generated chunks.</returns>
-    void DispatchGeneration(IReadOnlyList<ChunkKey> keys, Action<ChunkRenderBatch> output, ChunkRenderBatch existingBatch = null);
+    void DispatchGeneration(ChunkKey?[] keys, int count, Dictionary<int, ChunkKey?> modifications, Action<ChunkRenderBatch> output, ChunkRenderBatch existingBatch = null);
 
     /// <summary>
     /// Used for generators that operate on a schedule.

--- a/Terrain/Engine/MarchingCubesChunkGenerator.cs
+++ b/Terrain/Engine/MarchingCubesChunkGenerator.cs
@@ -29,7 +29,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
     private ComputeShader MarchingShader;
 
     // Shared GPU state
-    private ComputeBuffer DensityBuffer;           // RWStructuredBuffer<float>  (voxel scalar field)
     private ComputeBuffer SurfaceChunkInputBuffer; // StructuredBuffer<ChunkInput> for mask pass
     private ComputeBuffer GenerateChunkInputBuffer;// StructuredBuffer<ChunkInput> for full gen
     private ComputeBuffer BiomeBuffer;             // StructuredBuffer<BiomeData> (small table)
@@ -112,7 +111,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
     /// <exception cref="System.NotImplementedException"></exception>
     public void Dispose()
     {
-        DensityBuffer.Dispose();
         SurfaceChunkInputBuffer.Dispose();
         GenerateChunkInputBuffer.Dispose();
         BiomeBuffer.Dispose();
@@ -257,12 +255,14 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         ComputeBuffer triangleBuffer = existingBatch?.Triangle;
         ComputeBuffer detailBuffer = existingBatch?.Details;
         ComputeBuffer argsBuffer = existingBatch?.Args;
+        ComputeBuffer densityBuffer = existingBatch?.DensityMap;
 
         if (existingBatch == null)
         {
             triangleBuffer = new ComputeBuffer(60000, Marshal.SizeOf<TriangleDataGPU>(), ComputeBufferType.Append);
             detailBuffer = new ComputeBuffer(60000, Marshal.SizeOf<ChunkDetailDataGPU>(), ComputeBufferType.Append | ComputeBufferType.Structured);
             argsBuffer = new ComputeBuffer(1, 5 * sizeof(uint), ComputeBufferType.IndirectArguments);
+            densityBuffer = CreateDensityBuffer();
         }
 
         triangleBuffer.SetCounterValue(0);
@@ -270,7 +270,7 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
 
         // Generate density
         MarchingShader.SetBuffer(genKernel, "ChunkInputs", GenerateChunkInputBuffer);
-        MarchingShader.SetBuffer(genKernel, "DensityMap", DensityBuffer);
+        MarchingShader.SetBuffer(genKernel, "DensityMap", densityBuffer);
 
         // NOTE: thread group dims assume [numthreads(4,4,4)] and X packs chunkIndex*XWithinChunk
         int genGroupSize = Mathf.CeilToInt(samplesPerAxis / 4f);
@@ -278,7 +278,7 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
 
         // Marching cubes
         MarchingShader.SetBuffer(marchKernel, "ChunkInputs", GenerateChunkInputBuffer);
-        MarchingShader.SetBuffer(marchKernel, "DensityMap", DensityBuffer);
+        MarchingShader.SetBuffer(marchKernel, "DensityMap", densityBuffer);
         MarchingShader.SetBuffer(marchKernel, "InitialDetailBuffer", detailBuffer);
         MarchingShader.SetBuffer(marchKernel, "TriangleBuffer", triangleBuffer);
 
@@ -312,7 +312,7 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         */
 
         // Hand back a draw-ready batch (triangles + args + bounds computed from keys)
-        output.Invoke(new ChunkRenderBatch(triangleBuffer, detailBuffer, argsBuffer, keys, this.chunkServices));
+        output.Invoke(new ChunkRenderBatch(triangleBuffer, detailBuffer, densityBuffer, argsBuffer, keys, this.chunkServices));
     }
 
     /// <summary>
@@ -332,12 +332,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
 
         this.MarchingShader.SetConstantBuffer("TerrainDensityOptions", DensityOptionsBuffer, 0, Marshal.SizeOf<TerrainDensityOptions>());
         this.MarchingShader.SetConstantBuffer("PlanetDensityOptions", PlanetOptionsBuffer, 0, Marshal.SizeOf<PlanetDensityOptions>());
-
-        // Scalar field big enough for 128 chunks at current chunk size (rough over-alloc)
-        int samples = CubesPerAxis + 1 + (2 * BorderSamples);
-        int sampleCountPerChunk = samples * samples * samples;
-        int maxTotalSamples = sampleCountPerChunk * GenerateCap;
-        DensityBuffer = new ComputeBuffer(maxTotalSamples, sizeof(float));
 
         // Per-kernel inputs + mask output
         SurfaceChunkInputBuffer = new ComputeBuffer(SurfaceCap, Marshal.SizeOf<ChunkDispatchKeyGPU>());
@@ -405,6 +399,15 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         }
 
         GenerateChunkInputBuffer.SetData(InputGenerate, 0, 0, n);
+    }
+
+    private ComputeBuffer CreateDensityBuffer()
+    {
+        // Scalar field big enough for 128 chunks at current chunk size (rough over-alloc)
+        int samples = CubesPerAxis + 1 + (2 * BorderSamples);
+        int sampleCountPerChunk = samples * samples * samples;
+        int maxTotalSamples = sampleCountPerChunk * GenerateCap;
+        return new ComputeBuffer(maxTotalSamples, sizeof(float));
     }
 
     public int CubesPerAxis => densityOptions.CubesPerAxis;

--- a/Terrain/Engine/MarchingCubesChunkGenerator.cs
+++ b/Terrain/Engine/MarchingCubesChunkGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Unity.Collections;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -229,9 +230,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         if (batchSize == 0)
             return;
 
-        // Fill the reusable input list + upload to the per-kernel input buffer.
-        FillGenerateChunkInputs(keys, keyCount);
-
         ComputeBuffer triangleBuffer = existingBatch?.Triangle;
         ComputeBuffer detailBuffer = existingBatch?.Details;
         ComputeBuffer argsBuffer = existingBatch?.Args;
@@ -248,13 +246,22 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         triangleBuffer.SetCounterValue(0);
         detailBuffer.SetCounterValue(0);
 
-        // Generate density
-        MarchingShader.SetBuffer(genKernel, "ChunkInputs", GenerateChunkInputBuffer);
-        MarchingShader.SetBuffer(genKernel, "DensityMap", densityBuffer);
+        // Fill total input.
+        FillGenerateChunkInputs(keys, keyCount);
 
-        // NOTE: thread group dims assume [numthreads(4,4,4)] and X packs chunkIndex*XWithinChunk
-        int genGroupSize = Mathf.CeilToInt(samplesPerAxis / 4f);
-        MarchingShader.Dispatch(genKernel, batchSize * genGroupSize, genGroupSize, genGroupSize);
+        MarchingShader.SetBuffer(genKernel, "DensityMap", densityBuffer);
+        MarchingShader.SetBuffer(genKernel, "ChunkInputs", GenerateChunkInputBuffer);
+
+        List<(int, int)> ranges = GroupContiguous(mods);
+        foreach (var (start, end) in ranges)
+        {
+            // Generate density
+            MarchingShader.SetInt("Offset", start);
+
+            // NOTE: thread group dims assume [numthreads(4,4,4)] and X packs chunkIndex*XWithinChunk
+            int genGroupSize = Mathf.CeilToInt(samplesPerAxis / 4f);
+            MarchingShader.Dispatch(genKernel, (end - start + 1) * genGroupSize, genGroupSize, genGroupSize);
+        }
 
         // Marching cubes
         MarchingShader.SetBuffer(marchKernel, "ChunkInputs", GenerateChunkInputBuffer);
@@ -269,7 +276,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
 
         // Build indirect args from append count
         MarchingShader.SetBuffer(argsKernel, "CountBuffer", countBuffer);
-        MarchingShader.SetBuffer(argsKernel, "TriangleBuffer", triangleBuffer);
         MarchingShader.SetBuffer(argsKernel, "ArgsBuffer", argsBuffer);
         MarchingShader.Dispatch(argsKernel, 1, 1, 1);
 
@@ -387,6 +393,43 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         int sampleCountPerChunk = samples * samples * samples;
         int maxTotalSamples = sampleCountPerChunk * GenerateCap;
         return new ComputeBuffer(maxTotalSamples, sizeof(float));
+    }
+
+    /// <summary>
+    /// Groups modification indices into contiguous ranges for efficient job dispatch.
+    /// </summary>
+    public static List<(int start, int end)> GroupContiguous(Dictionary<int, ChunkKey?> mods)
+    {
+        if (mods.Count == 0)
+            return new List<(int, int)>();
+
+        var sorted = mods.Keys.OrderBy(i => i);
+        List<(int start, int end)> groups = new();
+        int rangeStart = -1, prev = -1;
+
+        foreach (int idx in sorted)
+        {
+            if (rangeStart == -1)
+            {
+                rangeStart = prev = idx;
+                continue;
+            }
+
+            if (idx == prev + 1)
+            {
+                // contiguous, extend current range
+                prev = idx;
+            }
+            else
+            {
+                // gap detected.
+                groups.Add((rangeStart, prev));
+                rangeStart = prev = idx;
+            }
+        }
+
+        groups.Add((rangeStart, prev));
+        return groups;
     }
 
     public int CubesPerAxis => densityOptions.CubesPerAxis;

--- a/Terrain/Engine/MarchingCubesChunkGenerator.cs
+++ b/Terrain/Engine/MarchingCubesChunkGenerator.cs
@@ -398,6 +398,7 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
             var ctx = keys[i];
             InputGenerate.Add(new ChunkDispatchKeyGPU
             {
+                GlobalIndex = (uint)i,
                 CoordPos = ctx.Coordinates,
                 LodIndex = ctx.LODIndex
             });

--- a/Terrain/Engine/MarchingCubesChunkGenerator.cs
+++ b/Terrain/Engine/MarchingCubesChunkGenerator.cs
@@ -16,13 +16,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
     private const int SurfaceCap = 512;
     private const int GenerateCap = 64;
 
-    private struct TerrainJob
-    {
-        public IReadOnlyList<ChunkKey> Keys;
-        public Action<ChunkRenderBatch> Output;
-        public ChunkRenderBatch ExistingBatch;
-    }
-
     private IChunkServices chunkServices;
 
     // Shaders doing the real work
@@ -59,8 +52,6 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
     private int detailKernel;
     private int argsKernel;
 
-    private List<TerrainJob> Jobs = new();
-
     /// <summary>
     /// Initialize a new instance of the <see cref="MarchingCubesChunkGenerator"/> class.
     /// </summary>
@@ -91,18 +82,9 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         private set { chunkMaterial = value; }
     }
 
-    /// <summary>
-    /// Process multiple jobs from the queue to generate chunks.
-    /// </summary>
     public void Update()
     {
-        if (this.Jobs.Count == 0) return;
 
-        ConsoleTimer.Start("MC.Gen");
-
-        ProcessBatch(Jobs[0].Keys, Jobs[0].Output, Jobs[0].ExistingBatch); Jobs.RemoveAt(0);
-
-        ConsoleTimer.Stop("MC.Gen");
     }
 
     /// <summary>
@@ -126,17 +108,15 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         chunkMaterial = null;
         InputSurface.Clear();
         InputGenerate.Clear();
-
-        Jobs.Clear();
     }
 
     /// <summary>
     /// Full marching-cubes path. Builds density for the batch, runs MC, returns triangle + args buffers.
     /// This job will be queued and ran in a further update to reduce GPU pressure.
     /// </summary>
-    public void DispatchGeneration(IReadOnlyList<ChunkKey> keys, Action<ChunkRenderBatch> output, ChunkRenderBatch existingBatch = null)
+    public void DispatchGeneration(ChunkKey?[] keys, int keyCount, Dictionary<int, ChunkKey?> modifications, Action<ChunkRenderBatch> output, ChunkRenderBatch existingBatch = null)
     {
-        this.Jobs.Add(new TerrainJob() { Keys = keys, Output = output, ExistingBatch = existingBatch });
+        ProcessBatch(keys, keyCount, modifications, output, existingBatch);
     }
 
     /// <summary>
@@ -233,9 +213,9 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
     /// <summary>
     /// Full marching-cubes path. Builds density for the batch, runs MC, returns triangle + args buffers.
     /// </summary>
-    private void ProcessBatch(IReadOnlyList<ChunkKey> keys, Action<ChunkRenderBatch> output, ChunkRenderBatch existingBatch = null)
+    private void ProcessBatch(ChunkKey?[] keys, int keyCount, Dictionary<int,ChunkKey?> mods, Action<ChunkRenderBatch> output, ChunkRenderBatch existingBatch = null)
     {
-        int batchSize = keys.Count;
+        int batchSize = keyCount;
 
         int cubesPerAxis = CubesPerAxis;
         int samplesPerAxis = CubesPerAxis + 1 + (2 * BorderSamples);
@@ -250,7 +230,7 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
             return;
 
         // Fill the reusable input list + upload to the per-kernel input buffer.
-        FillGenerateChunkInputs(keys);
+        FillGenerateChunkInputs(keys, keyCount);
 
         ComputeBuffer triangleBuffer = existingBatch?.Triangle;
         ComputeBuffer detailBuffer = existingBatch?.Details;
@@ -312,7 +292,7 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
         */
 
         // Hand back a draw-ready batch (triangles + args + bounds computed from keys)
-        output.Invoke(new ChunkRenderBatch(triangleBuffer, detailBuffer, densityBuffer, argsBuffer, keys, this.chunkServices));
+        output.Invoke(new ChunkRenderBatch(triangleBuffer, detailBuffer, densityBuffer, argsBuffer, this.chunkServices));
     }
 
     /// <summary>
@@ -382,14 +362,13 @@ public class MarchingCubesChunkGenerator : IChunkGenerator
     /// <summary>
     /// Refill the reusable generate-input list and upload. Same deal as surface path.
     /// </summary>
-    private void FillGenerateChunkInputs(IReadOnlyList<ChunkKey> keys)
+    private void FillGenerateChunkInputs(ChunkKey?[] keys, int n)
     {
-        int n = keys.Count;
         InputGenerate.Clear();
 
         for (int i = 0; i < n; i++)
         {
-            var ctx = keys[i];
+            var ctx = keys[i].Value;
             InputGenerate.Add(new ChunkDispatchKeyGPU
             {
                 GlobalIndex = (uint)i,

--- a/Terrain/Systems/Generation/ChunkGenerationProcessor.cs
+++ b/Terrain/Systems/Generation/ChunkGenerationProcessor.cs
@@ -86,7 +86,7 @@ public class ChunkGenerationProcessor : IDisposable
     /// </summary>
     public void RemoveChunk(ChunkKey key)
     {
-        this.removalQueue.Add(new (key, 10));
+        this.removalQueue.Add(new (key, 60));
     }
 
     /// <summary>

--- a/Terrain/Systems/Rendering/ChunkRenderBatch.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBatch.cs
@@ -21,6 +21,11 @@ public class ChunkRenderBatch : IDisposable
     public ComputeBuffer Triangle;
 
     /// <summary>
+    /// The density map used for the render batch.
+    /// </summary>
+    public ComputeBuffer DensityMap;
+
+    /// <summary>
     /// Append buffer containing generated detail data for triangles.
     /// </summary>
     public ComputeBuffer Details;
@@ -43,13 +48,14 @@ public class ChunkRenderBatch : IDisposable
     /// <param name="keys">Chunk keys included in this batch (for bounds computation).</param>
     /// <param name="services">Layout/services used to convert chunk keys to world space.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="Args"/> is null.</exception>
-    public ChunkRenderBatch(ComputeBuffer Triangle, ComputeBuffer Details, ComputeBuffer Args, IReadOnlyList<ChunkKey> keys, IChunkServices services)
+    public ChunkRenderBatch(ComputeBuffer Triangle, ComputeBuffer Details, ComputeBuffer densityMap, ComputeBuffer Args, IReadOnlyList<ChunkKey> keys, IChunkServices services)
     {
         if (Args == null)
             throw new System.ArgumentNullException("args");
 
         this.Triangle = Triangle;
         this.Details = Details;
+        this.DensityMap = densityMap;
         this.Args = Args;
     }
 
@@ -70,10 +76,12 @@ public class ChunkRenderBatch : IDisposable
         if (Args != null) Args.Dispose();
         if (Triangle != null) Triangle.Dispose();
         if (Details != null) Details.Dispose();
+        if (DensityMap != null) DensityMap.Dispose();
 
         Args = null;
         Triangle = null;
         Details = null;
+        DensityMap = null;
         countBuffer.Dispose();
     }
 

--- a/Terrain/Systems/Rendering/ChunkRenderBatch.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBatch.cs
@@ -48,7 +48,7 @@ public class ChunkRenderBatch : IDisposable
     /// <param name="keys">Chunk keys included in this batch (for bounds computation).</param>
     /// <param name="services">Layout/services used to convert chunk keys to world space.</param>
     /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="Args"/> is null.</exception>
-    public ChunkRenderBatch(ComputeBuffer Triangle, ComputeBuffer Details, ComputeBuffer densityMap, ComputeBuffer Args, IReadOnlyList<ChunkKey> keys, IChunkServices services)
+    public ChunkRenderBatch(ComputeBuffer Triangle, ComputeBuffer Details, ComputeBuffer densityMap, ComputeBuffer Args, IChunkServices services)
     {
         if (Args == null)
             throw new System.ArgumentNullException("args");

--- a/Terrain/Systems/Rendering/ChunkRenderBucket.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBucket.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -31,7 +32,7 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// The last index used.
     /// </summary>
-    private int lastIndex;
+    private int nextIndex;
 
     /// <summary>
     /// The allowed amount of elements in this bucket.
@@ -52,7 +53,7 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// Give a small delay on tickets to update this way we get as many updates as possible.
     /// </summary>
-    private int RemainingTicksToUpdate = 5;
+    private int RemainingTicksToUpdate = 25;
 
     /// <summary>
     /// The generator used to dispatch generation requests.
@@ -117,23 +118,31 @@ public class ChunkRenderBucket : IDisposable
         if (index.ContainsKey(key) || IsFull) return false;
 
         int pos;
-        if (this.AvailableSlots.Count != 0)
+        if (AvailableSlots.Count != 0)
         {
-            pos = this.AvailableSlots.Dequeue();
-            items[pos] = key;
-            modifications[pos] = key;
+            int hole = AvailableSlots.Dequeue();
+
+            // Stale hole if it’s at/after the frontier. append instead
+            if (hole >= nextIndex)
+            {
+                pos = nextIndex;
+                nextIndex++;
+            }
+            else
+            {
+                pos = hole;
+            }
         }
         else
         {
-            pos = lastIndex;
-            items[lastIndex] = key;
-            lastIndex++;
+            pos = nextIndex;
+            nextIndex++;
         }
 
+        items[pos] = key;
         index[key] = pos;
-
-        this.MarkAsDirty(false);
-
+        modifications[pos] = key;
+        MarkAsDirty(false);
         return true;
     }
 
@@ -143,20 +152,29 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    public bool TryRemove(ChunkKey key)
+    public bool TryRemove(ChunkKey key, bool b = false)
     {
         if (!index.TryGetValue(key, out int i))
             return false;
 
-        if (i == lastIndex -1)
+        index.Remove(key);
+        items[i] = null;
+
+        if (!b)
+            modifications[i] = null;
+
+        if (i == nextIndex -1)
         {
-            lastIndex--;
+            nextIndex--;
+            while (nextIndex > 0 && items[nextIndex - 1] == null)
+                nextIndex--;
+        }
+        else
+        {
+            if (!b)
+                AvailableSlots.Enqueue(i);
         }
 
-        items[i] = null;
-        index.Remove(key);
-        modifications[i] = null;
-        AvailableSlots.Enqueue(i);
         this.MarkAsDirty(false);
 
         return true;
@@ -231,7 +249,7 @@ public class ChunkRenderBucket : IDisposable
         if (forceNow || this.IsFull)
             this.RemainingTicksToUpdate = 0;
         else
-            this.RemainingTicksToUpdate = 5;
+            this.RemainingTicksToUpdate = 25;
     }
 
     /// <summary>
@@ -251,7 +269,7 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     protected virtual void GenerateCore(ChunkKey?[] items, Dictionary<int, ChunkKey?> modifications, Action<ChunkRenderBatch> onDone)
     {
-        chunkGenerator.DispatchGeneration(items, modifications, onDone, this.renderData);
+        chunkGenerator.DispatchGeneration(items, nextIndex, modifications, onDone, this.renderData);
     }
 
     /// <summary>
@@ -259,29 +277,11 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     protected virtual void PreGenerateSort()
     {
-        int last = lastIndex - 1;
-
-        while (AvailableSlots.Count > 0)
+        while (AvailableSlots.Count > 0 && nextIndex -1 >= 0)
         {
-            int i = AvailableSlots.Dequeue();
-            if (i >= last)
-            {
-                continue;
-            }
-
-            ChunkKey lastItem = items[last].Value;
-
-            // Modify the modification.
-            modifications[i] = lastItem;
-
-            // Move last item into hole.
-            items[i] = lastItem;
-            index[lastItem] = i;
-
-            // Clear tail
-            items[last] = null;
-            last--;
-            lastIndex--;
+            var item = items[nextIndex - 1].Value;
+            TryRemove(item, true);
+            TryAdd(item);
         }
     }
 

--- a/Terrain/Systems/Rendering/ChunkRenderBucket.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBucket.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -13,8 +11,7 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// The collection of items used in this bucket.
     /// </summary>
-    private List<ChunkKey?> items;
-    private List<ChunkKey> tempItems;
+    private ChunkKey?[] items;
 
     /// <summary>
     /// Side index so Contains/Remove are O(1). No linear scans.
@@ -22,9 +19,19 @@ public class ChunkRenderBucket : IDisposable
     private readonly Dictionary<ChunkKey, int> index;
 
     /// <summary>
-    /// A collection of available slots.
+    /// A list of available spots.
     /// </summary>
     private Queue<int> AvailableSlots;
+
+    /// <summary>
+    /// A list of modified positions since the last generation.
+    /// </summary>
+    private readonly Dictionary<int, ChunkKey?> modifications;
+
+    /// <summary>
+    /// The last index used.
+    /// </summary>
+    private int lastIndex;
 
     /// <summary>
     /// The allowed amount of elements in this bucket.
@@ -65,12 +72,12 @@ public class ChunkRenderBucket : IDisposable
     /// <param name="chunkGenerator"></param>
     public ChunkRenderBucket(int capacity, IChunkGenerator chunkGenerator)
     {
-        this.items = new List<ChunkKey?>(capacity);
-        this.tempItems = new List<ChunkKey>(capacity);
+        this.items = new ChunkKey?[capacity];
         this.index = new(capacity);
 
         this.capacity = capacity;
-        this.AvailableSlots = new Queue<int>();
+        this.AvailableSlots = new Queue<int>(capacity);
+        this.modifications = new(capacity);
 
         this.chunkGenerator = chunkGenerator;
     }
@@ -114,11 +121,13 @@ public class ChunkRenderBucket : IDisposable
         {
             pos = this.AvailableSlots.Dequeue();
             items[pos] = key;
+            modifications[pos] = key;
         }
         else
         {
-            pos = items.Count;
-            items.Add(key);
+            pos = lastIndex;
+            items[lastIndex] = key;
+            lastIndex++;
         }
 
         index[key] = pos;
@@ -136,15 +145,18 @@ public class ChunkRenderBucket : IDisposable
     /// <returns></returns>
     public bool TryRemove(ChunkKey key)
     {
-        if (!index.TryGetValue(key, out int i)) return false;
+        if (!index.TryGetValue(key, out int i))
+            return false;
 
-        // Remove.
+        if (i == lastIndex -1)
+        {
+            lastIndex--;
+        }
+
         items[i] = null;
         index.Remove(key);
-
-        // Add slot.
+        modifications[i] = null;
         AvailableSlots.Enqueue(i);
-
         this.MarkAsDirty(false);
 
         return true;
@@ -155,9 +167,8 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     public void Clear()
     {
-        this.items.Clear();
+        this.items = null;
         this.index.Clear();
-        this.tempItems.Clear();
         this.AvailableSlots.Clear();
     }
 
@@ -238,9 +249,40 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// Core logic that actually performs generation. Override in subclasses.
     /// </summary>
-    protected virtual void GenerateCore(List<ChunkKey> items, Action<ChunkRenderBatch> onDone)
+    protected virtual void GenerateCore(ChunkKey?[] items, Dictionary<int, ChunkKey?> modifications, Action<ChunkRenderBatch> onDone)
     {
-        chunkGenerator.DispatchGeneration(items, onDone, this.renderData);
+        chunkGenerator.DispatchGeneration(items, modifications, onDone, this.renderData);
+    }
+
+    /// <summary>
+    /// A pregeneration sort function to sort the collection before sending to dispatch.
+    /// </summary>
+    protected virtual void PreGenerateSort()
+    {
+        int last = lastIndex - 1;
+
+        while (AvailableSlots.Count > 0)
+        {
+            int i = AvailableSlots.Dequeue();
+            if (i >= last)
+            {
+                continue;
+            }
+
+            ChunkKey lastItem = items[last].Value;
+
+            // Modify the modification.
+            modifications[i] = lastItem;
+
+            // Move last item into hole.
+            items[i] = lastItem;
+            index[lastItem] = i;
+
+            // Clear tail
+            items[last] = null;
+            last--;
+            lastIndex--;
+        }
     }
 
     /// <summary>
@@ -251,53 +293,10 @@ public class ChunkRenderBucket : IDisposable
         if (GenerateInProgress || this.IsEmpty) return;
         GenerateInProgress = true;
 
-        var moves = CompactBeforeGenerate();
+        PreGenerateSort();
+        GenerateCore(items, modifications, OnGenerateCompleted);
 
-        this.tempItems.Clear();
-        foreach (var entry in this.items)
-        {
-            if (entry.HasValue)
-                tempItems.Add(entry.Value);
-        }
-
-        GenerateCore(tempItems, OnGenerateCompleted);
-    }
-
-    private Dictionary<int, ChunkKey> CompactBeforeGenerate()
-    {
-        var moved = new Dictionary<int, ChunkKey>();
-
-        if (AvailableSlots.Count == 0)
-            return moved;
-
-        while (AvailableSlots.Count > 0)
-        {
-            int vacant = AvailableSlots.Dequeue();
-
-            // Stop if vacancy is already beyond current end
-            if (vacant >= items.Count - 1)
-                continue;
-
-            // Pull last valid chunk
-            int lastIndex = items.Count - 1;
-            var lastVal = items[lastIndex];
-            if (!lastVal.HasValue)
-            {
-                // skip trailing nulls
-                items.RemoveAt(lastIndex);
-                continue;
-            }
-
-            // Move last chunk down
-            items[vacant] = lastVal;
-            index[lastVal.Value] = vacant;
-            moved[vacant] = lastVal.Value;
-
-            // Trim tail
-            items.RemoveAt(lastIndex);
-        }
-
-        return moved;
+        this.modifications.Clear();
     }
 
     /// <summary>

--- a/Terrain/Systems/Rendering/ChunkRenderBucket.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBucket.cs
@@ -248,9 +248,10 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     private void Generate()
     {
-        if (GenerateInProgress || this.IsEmpty)
-            return;
+        if (GenerateInProgress || this.IsEmpty) return;
         GenerateInProgress = true;
+
+        var moves = CompactBeforeGenerate();
 
         this.tempItems.Clear();
         foreach (var entry in this.items)
@@ -260,6 +261,43 @@ public class ChunkRenderBucket : IDisposable
         }
 
         GenerateCore(tempItems, OnGenerateCompleted);
+    }
+
+    private Dictionary<int, ChunkKey> CompactBeforeGenerate()
+    {
+        var moved = new Dictionary<int, ChunkKey>();
+
+        if (AvailableSlots.Count == 0)
+            return moved;
+
+        while (AvailableSlots.Count > 0)
+        {
+            int vacant = AvailableSlots.Dequeue();
+
+            // Stop if vacancy is already beyond current end
+            if (vacant >= items.Count - 1)
+                continue;
+
+            // Pull last valid chunk
+            int lastIndex = items.Count - 1;
+            var lastVal = items[lastIndex];
+            if (!lastVal.HasValue)
+            {
+                // skip trailing nulls
+                items.RemoveAt(lastIndex);
+                continue;
+            }
+
+            // Move last chunk down
+            items[vacant] = lastVal;
+            index[lastVal.Value] = vacant;
+            moved[vacant] = lastVal.Value;
+
+            // Trim tail
+            items.RemoveAt(lastIndex);
+        }
+
+        return moved;
     }
 
     /// <summary>

--- a/Terrain/Systems/Rendering/ChunkRenderBucket.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBucket.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -53,7 +53,7 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// Give a small delay on tickets to update this way we get as many updates as possible.
     /// </summary>
-    private int RemainingTicksToUpdate = 25;
+    private int RemainingTicksToUpdate = 15;
 
     /// <summary>
     /// The generator used to dispatch generation requests.
@@ -73,10 +73,11 @@ public class ChunkRenderBucket : IDisposable
     /// <param name="chunkGenerator"></param>
     public ChunkRenderBucket(int capacity, IChunkGenerator chunkGenerator)
     {
+        this.capacity = capacity;
+
         this.items = new ChunkKey?[capacity];
         this.index = new(capacity);
 
-        this.capacity = capacity;
         this.AvailableSlots = new Queue<int>(capacity);
         this.modifications = new(capacity);
 
@@ -113,6 +114,7 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     /// <param name="key"></param>
     /// <returns>True if added successfully.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryAdd(ChunkKey key)
     {
         if (index.ContainsKey(key) || IsFull) return false;
@@ -152,7 +154,20 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    public bool TryRemove(ChunkKey key, bool b = false)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRemove(ChunkKey key)
+    {
+        return TryRemoveInternal(key);
+    }
+
+    /// <summary>
+    /// O(1) remove via swap-back. Order does NOT matter here.
+    /// If we remove "enough", flip dirty so we rebuild next chance we get.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="ignoreQueue"></param>
+    /// <returns></returns>
+    private bool TryRemoveInternal(ChunkKey key, bool ignoreQueue = false)
     {
         if (!index.TryGetValue(key, out int i))
             return false;
@@ -160,10 +175,12 @@ public class ChunkRenderBucket : IDisposable
         index.Remove(key);
         items[i] = null;
 
-        if (!b)
+        // If ignoreQueu is true we are doing some house cleaning
+        // and do not want 
+        if (!ignoreQueue)
             modifications[i] = null;
 
-        if (i == nextIndex -1)
+        if (i == nextIndex - 1)
         {
             nextIndex--;
             while (nextIndex > 0 && items[nextIndex - 1] == null)
@@ -171,7 +188,9 @@ public class ChunkRenderBucket : IDisposable
         }
         else
         {
-            if (!b)
+            // If this function is being called internally in side this class.
+            // we may want to avoid adding it to the queue as we are doing a cleanup.
+            if (!ignoreQueue)
                 AvailableSlots.Enqueue(i);
         }
 
@@ -185,7 +204,9 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     public void Clear()
     {
-        this.items = null;
+        Array.Clear(items, 0, nextIndex);
+        nextIndex = 0;
+
         this.index.Clear();
         this.AvailableSlots.Clear();
     }
@@ -202,6 +223,8 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     public void Update()
     {
+        if (!IsDirty) return;
+
         // In some cases as we are getting new data we want to delay the update
         // this way we dont regenerate this bucket just for it go through another
         // immediate update.
@@ -213,7 +236,7 @@ public class ChunkRenderBucket : IDisposable
 
         if (IsDirty && !this.GenerateInProgress)
         {
-            this.Generate();
+            this.DispatchGeneration();
         }
     }
 
@@ -239,20 +262,6 @@ public class ChunkRenderBucket : IDisposable
     }
 
     /// <summary>
-    /// Mark this bucket as dirty to request a regeneration. Optionally force the update to happen now.
-    /// </summary>
-    /// <param name="forceNow">The update will happen right away and not consider its options.</param>
-    public void MarkAsDirty(bool forceNow)
-    {
-        this.IsDirty = true;
-
-        if (forceNow || this.IsFull)
-            this.RemainingTicksToUpdate = 0;
-        else
-            this.RemainingTicksToUpdate = 25;
-    }
-
-    /// <summary>
     /// Dispose of the renderData and release memory.
     /// </summary>
     public void Dispose()
@@ -265,38 +274,38 @@ public class ChunkRenderBucket : IDisposable
     }
 
     /// <summary>
-    /// Core logic that actually performs generation. Override in subclasses.
+    /// Mark this bucket as dirty to request a regeneration. Optionally force the update to happen now.
     /// </summary>
-    protected virtual void GenerateCore(ChunkKey?[] items, Dictionary<int, ChunkKey?> modifications, Action<ChunkRenderBatch> onDone)
+    /// <param name="forceNow">The update will happen right away and not consider its options.</param>
+    public void MarkAsDirty(bool forceNow)
     {
-        chunkGenerator.DispatchGeneration(items, nextIndex, modifications, onDone, this.renderData);
+        this.IsDirty = true;
+
+        if (forceNow)
+            this.RemainingTicksToUpdate = 0;
+        else
+            this.RemainingTicksToUpdate = 25;
     }
 
     /// <summary>
     /// A pregeneration sort function to sort the collection before sending to dispatch.
     /// </summary>
-    protected virtual void PreGenerateSort()
+    protected virtual void PreDispatchGeneration()
     {
-        while (AvailableSlots.Count > 0 && nextIndex -1 >= 0)
+        while (AvailableSlots.Count > 0 && nextIndex - 1 >= 0)
         {
             var item = items[nextIndex - 1].Value;
-            TryRemove(item, true);
+            TryRemoveInternal(item, true);
             TryAdd(item);
         }
     }
 
     /// <summary>
-    /// Call ths bucket with the included elements to be generated.
+    /// Call the <see cref="IChunkGenerator"/> dispatch function to deploy this batch for generation.
     /// </summary>
-    private void Generate()
+    protected virtual void OnDispatchGeneration()
     {
-        if (GenerateInProgress || this.IsEmpty) return;
-        GenerateInProgress = true;
-
-        PreGenerateSort();
-        GenerateCore(items, modifications, OnGenerateCompleted);
-
-        this.modifications.Clear();
+        chunkGenerator.DispatchGeneration(items, nextIndex, modifications, OnDispatchGenerationCompleted, this.renderData);
     }
 
     /// <summary>
@@ -304,7 +313,7 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     /// <remarks>This was changed from a lambda as I track down a stuttering issue and GC issues.</remarks>
     /// <param name="output"></param>
-    private void OnGenerateCompleted(ChunkRenderBatch output)
+    protected virtual void OnDispatchGenerationCompleted(ChunkRenderBatch output)
     {
         RenderData = output;
 
@@ -323,5 +332,19 @@ public class ChunkRenderBucket : IDisposable
 
         this.IsDirty = false;
         this.GenerateInProgress = false;
+    }
+
+    /// <summary>
+    /// Call ths bucket with the included elements to be generated.
+    /// </summary>
+    private void DispatchGeneration()
+    {
+        if (GenerateInProgress || this.IsEmpty) return;
+        GenerateInProgress = true;
+
+        PreDispatchGeneration();
+        OnDispatchGeneration();
+
+        this.modifications.Clear();
     }
 }

--- a/Terrain/Systems/Rendering/ChunkRenderBucket.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBucket.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -11,12 +13,18 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// The collection of items used in this bucket.
     /// </summary>
-    private readonly List<ChunkKey> items;
+    private List<ChunkKey?> items;
+    private List<ChunkKey> tempItems;
 
     /// <summary>
     /// Side index so Contains/Remove are O(1). No linear scans.
     /// </summary>
     private readonly Dictionary<ChunkKey, int> index;
+
+    /// <summary>
+    /// A collection of available slots.
+    /// </summary>
+    private Queue<int> AvailableSlots;
 
     /// <summary>
     /// The allowed amount of elements in this bucket.
@@ -57,10 +65,12 @@ public class ChunkRenderBucket : IDisposable
     /// <param name="chunkGenerator"></param>
     public ChunkRenderBucket(int capacity, IChunkGenerator chunkGenerator)
     {
-        this.items = new(capacity);
+        this.items = new List<ChunkKey?>(capacity);
+        this.tempItems = new List<ChunkKey>(capacity);
         this.index = new(capacity);
 
         this.capacity = capacity;
+        this.AvailableSlots = new Queue<int>();
 
         this.chunkGenerator = chunkGenerator;
     }
@@ -83,12 +93,12 @@ public class ChunkRenderBucket : IDisposable
     /// <summary>
     /// Has this bucket reached maximum capacity.
     /// </summary>
-    public virtual bool IsFull => items.Count == capacity;
+    public virtual bool IsFull => index.Count >= capacity;
 
     /// <summary>
     /// Has this bucket no items?
     /// </summary>
-    public bool IsEmpty => items.Count == 0;
+    public bool IsEmpty => index.Count == 0;
 
     /// <summary>
     /// Fast append. If we add anything, mark dirty so we rebuild soon.
@@ -97,10 +107,21 @@ public class ChunkRenderBucket : IDisposable
     /// <returns>True if added successfully.</returns>
     public bool TryAdd(ChunkKey key)
     {
-        if (index.ContainsKey(key) || items.Count >= capacity) return false;
+        if (index.ContainsKey(key) || IsFull) return false;
 
-        index[key] = items.Count;
-        items.Add(key);
+        int pos;
+        if (this.AvailableSlots.Count != 0)
+        {
+            pos = this.AvailableSlots.Dequeue();
+            items[pos] = key;
+        }
+        else
+        {
+            pos = items.Count;
+            items.Add(key);
+        }
+
+        index[key] = pos;
 
         this.MarkAsDirty(false);
 
@@ -117,14 +138,12 @@ public class ChunkRenderBucket : IDisposable
     {
         if (!index.TryGetValue(key, out int i)) return false;
 
-        int last = items.Count - 1;
-        var swap = items[last];
-
-        items[i] = swap;
-        items.RemoveAt(last);
-
-        index[swap] = i;
+        // Remove.
+        items[i] = null;
         index.Remove(key);
+
+        // Add slot.
+        AvailableSlots.Enqueue(i);
 
         this.MarkAsDirty(false);
 
@@ -138,6 +157,8 @@ public class ChunkRenderBucket : IDisposable
     {
         this.items.Clear();
         this.index.Clear();
+        this.tempItems.Clear();
+        this.AvailableSlots.Clear();
     }
 
     /// <summary>
@@ -173,7 +194,7 @@ public class ChunkRenderBucket : IDisposable
     /// <param name="vertexMat"></param>
     public void Draw(CommandBuffer cdb, Material vertexMat)
     {
-        if (items.Count == 0) return;
+        if (IsEmpty) return;
 
         var rd = RenderData;
         if (rd == null || rd.IsDisposed || rd.Triangle == null || rd.Args == null) return;
@@ -227,11 +248,18 @@ public class ChunkRenderBucket : IDisposable
     /// </summary>
     private void Generate()
     {
-        if (GenerateInProgress || this.items.Count == 0)
+        if (GenerateInProgress || this.IsEmpty)
             return;
         GenerateInProgress = true;
 
-        GenerateCore(items, OnGenerateCompleted);
+        this.tempItems.Clear();
+        foreach (var entry in this.items)
+        {
+            if (entry.HasValue)
+                tempItems.Add(entry.Value);
+        }
+
+        GenerateCore(tempItems, OnGenerateCompleted);
     }
 
     /// <summary>

--- a/Terrain/Systems/Rendering/ChunkRenderBucketCollection.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderBucketCollection.cs
@@ -159,8 +159,11 @@ public class ChunkRenderBucketCollection : IDisposable
     /// </summary>
     public void Dispose()
     {
-        for (int i = 0; i < buckets.Count; i++)
-            buckets[i].Dispose();
+        if (buckets != null)
+        {
+            for (int i = 0; i < buckets.Count; i++)
+                buckets[i].Dispose();
+        }
 
         foreach (var go in colliders.Values)
         {

--- a/Terrain/Systems/Rendering/ChunkRenderFeature.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderFeature.cs
@@ -31,4 +31,10 @@ public class ChunkRenderFeature : ScriptableRendererFeature
         if (Router != null && pass != null)
             renderer.EnqueuePass(pass);
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        pass.Dispose();
+        base.Dispose(disposing);
+    }
 }

--- a/Terrain/Systems/Rendering/ChunkRenderPass.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderPass.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
 using UnityEngine.Rendering.Universal;
@@ -7,9 +8,9 @@ using UnityEngine.Rendering.Universal;
 /// Injected into URP after transparents so it lines up with shaders using queue ~3000.
 /// Works under both legacy and RenderGraph pipelines.
 /// </summary>
-public class ChunkRenderPass : ScriptableRenderPass
+public class ChunkRenderPass : ScriptableRenderPass, IDisposable
 {
-    private readonly ChunkRenderRouter router;
+    private ChunkRenderRouter router;
 
     /// <summary>
     /// Sets the router reference and when this pass should run.
@@ -18,6 +19,14 @@ public class ChunkRenderPass : ScriptableRenderPass
     {
         this.router = router;
         renderPassEvent = RenderPassEvent.AfterRenderingTransparents;
+    }
+
+    public void Dispose()
+    {
+        if (router != null)
+        {
+            router = null;
+        }
     }
 
     /// <summary>

--- a/Terrain/Systems/Rendering/ChunkRenderRouter.cs
+++ b/Terrain/Systems/Rendering/ChunkRenderRouter.cs
@@ -98,6 +98,8 @@ public class ChunkRenderRouter : IDisposable
     {
         foreach (var bucket in lodBuckets)
             bucket.Dispose();
+
+        lodBuckets = null;
     }
 
     /// <summary>
@@ -106,6 +108,8 @@ public class ChunkRenderRouter : IDisposable
     /// <param name="cmd"></param>
     public void FillCommandBuffer(CommandBuffer cmd)
     {
+        if (lodBuckets == null) return;
+
         foreach (var bucket in lodBuckets)
             bucket.Draw(cmd, chunkGenerator.GetMaterial);
     }


### PR DESCRIPTION
Made changes to ChunkRenderBucket so now when a bucket is sent for generation, the densityMap only generates for the modified chunks. Not for the entire bucket. This saves a lot of processing and makes our static FPS almost on par with our active FPS.

While doing this change, though, it showed quite a bit of work is needed to standardize many features. A lot of stuff is set statically and could use a 'global configuration' type manager. Like, the removal of old chunks in ChunkProcessManager was set to 5 ticks, while in ChunkRenderBucket, I switched to 15 ticks, which caused a flickering issue. 

What a nice improvement. 